### PR TITLE
Updates for dataURL and cache parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
       </div>
 
       <div class="results centered">
+        <label>
+          <input id="use-cache" type="checkbox" checked="checked" />&nbsp;
+          Use persistent cache?
+        </label>
         <button id="metadata-button">Create metadata</button>
         <textarea id="json-field" rows="20" cols="80"></textarea>
         <a id="download-link" class="hidden">Download metadata</a>

--- a/main.ts
+++ b/main.ts
@@ -10,7 +10,7 @@ import { SetDef, LocationTypes } from './types';
 var setDefs: SetDef[] = [];
 
 var fieldPacks = [
-  { id: 'season', name: 'Season', defaultValue: 'winter' },
+  { id: 'season', name: 'Season', defaultValue: '' },
   { id: 'occasionSlug', name: 'occasionSlug', defaultValue: '' },
   { id: 'endYear', name: 'End year', defaultValue: (new Date().getFullYear() - 1).toString() },
 ];

--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,7 @@ var setDefs: SetDef[] = [];
 var fieldPacks = [
   { id: 'season', name: 'Season', defaultValue: 'winter' },
   { id: 'occasionSlug', name: 'occasionSlug', defaultValue: '' },
-  { id: 'endYear', name: 'End year', defaultValue: '2023' },
+  { id: 'endYear', name: 'End year', defaultValue: (new Date().getFullYear() - 1).toString() },
 ];
 
 (async function go() {

--- a/tasks/generate-metadata.ts
+++ b/tasks/generate-metadata.ts
@@ -114,7 +114,7 @@ export async function generateMetadata({
       season: overallOpts.season,
       variable: setDef.variable,
       setType: setDef.name,
-      dataURL: `${DATA_URL_BASE}/api/v1/graphic-data/trend/?agg_time=${overallOpts.season}&station_id=${marketData[marketSlug].station}&trend_year_range=1970-${overallOpts.endYear}&variable=${setDef.variable}&format=csv`,
+      dataURL: setDef.downloadable ? `${DATA_URL_BASE}/api/v1/graphic-data/trend/?agg_time=${overallOpts.season}&station_id=${marketData[marketSlug].station}&trend_year_range=1970-${overallOpts.endYear}&variable=${setDef.variable}&format=csv` : null,
     };
   }
 }

--- a/tasks/generate-metadata.ts
+++ b/tasks/generate-metadata.ts
@@ -11,8 +11,7 @@ import omit from 'lodash.omit';
 const IMG_URL_BASE = 'https://images.climatecentral.org/web-image';
 const GRAPHICS_URL_BASE = 'https://graphics.climatecentral.org';
 // const GRAPHICS_URL_BASE = 'http://localhost:8000';
-const MARKETS_API =
-  'https://9pglbdveii.execute-api.us-east-1.amazonaws.com/stage/web-image?url=https%3A%2F%2Fapi.climatecentral.org%2Fv1%2Fcmmarket%2F&getRaw=true&contentType=application/json';
+const MARKETS_API = 'https://api.climatecentral.org/v1/cmmarket';
 
 var marketNamesForSlugs: Record<string, string>;
 

--- a/tasks/generate-metadata.ts
+++ b/tasks/generate-metadata.ts
@@ -8,10 +8,13 @@ import {
 } from '../types';
 import { multiplyArrayFactors } from './multiply-array-factors';
 import omit from 'lodash.omit';
+import { select } from 'd3-selection';
 
-const IMG_URL_BASE = 'https://images.climatecentral.org/web-image';
+// const IMG_URL_BASE = 'https://images.climatecentral.org/web-image';
+const IMG_URL_BASE = 'https://api.climatecentral.org/v1/web-image';
 const GRAPHICS_URL_BASE = 'https://graphics.climatecentral.org';
 // const GRAPHICS_URL_BASE = 'http://localhost:8000';
+const DATA_URL_BASE = 'https://rtc-prod.climatecentral.org';
 const MARKETS_API =
   'https://9pglbdveii.execute-api.us-east-1.amazonaws.com/stage/web-image?url=https%3A%2F%2Fapi.climatecentral.org%2Fv1%2Fcmmarket%2F&getRaw=true&contentType=application/json';
 
@@ -51,7 +54,7 @@ export async function generateMetadata({
     marketSlug: string,
     titleEnum: TitleEnum,
     backgroundCombo: BackgroundCombo,
-    lang: string
+    lang: string,
   ) {
 
     let graphicURLOpts: GraphicURLOpts = Object.assign({
@@ -91,10 +94,12 @@ export async function generateMetadata({
     ).toString();
     const graphicURL = `${GRAPHICS_URL_BASE}/?${queryString}`;
 
-    // const variable = variablesForGraphicSetNames[graphicSetName];
+    const cacheCheckbox = select('#use-cache');
+    const cache = cacheCheckbox.property('checked') ? 'persist' : 'none';
+
     return {
       graphicSet: setDef.name,
-      url: `${IMG_URL_BASE}/?delay=3000&url=${encodeURIComponent(graphicURL)}`,
+      url: `${IMG_URL_BASE}/?delay=3000&cache=${cache}&url=${encodeURIComponent(graphicURL)}`,
       graphicURL,
       title: titleEnum,
       lang,
@@ -109,7 +114,7 @@ export async function generateMetadata({
       season: overallOpts.season,
       variable: setDef.variable,
       setType: setDef.name,
-      dataURL: `https://rtc-prod.climatecentral.org/api/v1/graphic-data/trend/?agg_time=${overallOpts.season}&station_id=${marketData[marketSlug].station}&trend_year_range=1970-${overallOpts.endYear}&variable=${setDef.variable}&format=csv`,
+      dataURL: `${DATA_URL_BASE}/api/v1/graphic-data/trend/?agg_time=${overallOpts.season}&station_id=${marketData[marketSlug].station}&trend_year_range=1970-${overallOpts.endYear}&variable=${setDef.variable}&format=csv`,
     };
   }
 }

--- a/tasks/generate-metadata.ts
+++ b/tasks/generate-metadata.ts
@@ -11,7 +11,8 @@ import omit from 'lodash.omit';
 const IMG_URL_BASE = 'https://images.climatecentral.org/web-image';
 const GRAPHICS_URL_BASE = 'https://graphics.climatecentral.org';
 // const GRAPHICS_URL_BASE = 'http://localhost:8000';
-const MARKETS_API = 'https://api.climatecentral.org/v1/cmmarket';
+const MARKETS_API =
+  'https://9pglbdveii.execute-api.us-east-1.amazonaws.com/stage/web-image?url=https%3A%2F%2Fapi.climatecentral.org%2Fv1%2Fcmmarket%2F&getRaw=true&contentType=application/json';
 
 var marketNamesForSlugs: Record<string, string>;
 

--- a/types.ts
+++ b/types.ts
@@ -34,10 +34,16 @@ export interface GraphicURLOpts extends Omit<SetDef, 'locations'> {
   lang: string;
   noTitle: boolean;
   marketSlug?: string;
+  season?: string;
 }
 
 export interface OverallOpts {
   occasionSlug: string;
   season: string;
   endYear: number;
+}
+
+export interface Station {
+  name: string;
+  station: string;
 }


### PR DESCRIPTION
This updates the graphics packager with three essential changes (along with some minor ones):

1. Include a dataURL parameter in the metadata, which climatecentral.org may use in association with the data download function. We may want to make this an option (default true) that can be disabled for a given package.
2. Include a `cache=persist` parameter by default, so that requests to the URL will use the durable S3 cache (corresponding to a forthcoming screenshot service change).
3. Use api.climatecentral.org/v1/web-image instead of images.climatecentral.org/web-image. This has the effect simply of cutting out CloudFront. If we are serving static images from S3, given the nature of our product, we are getting little benefit from CloudFront, but bearing the cost in complexity and operational risk of potentially needing to invalidate the CloudFront cache if a change needs to be made, in addition to updating or clearing the persistent cache.

