### PR TITLE
Support visiting urls in manually entered JSON

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@ import handleError from 'handle-error-web';
 import { version } from './package.json';
 import { renderMetadataForm } from './renderers/render-metadata-form';
 import { renderSets } from './renderers/render-sets';
+import { renderMetadata } from './renderers/render-metadata';
 import { runMetadataGeneration } from './updaters/run-metadata-generation';
 import { CacheWarmingUpdater } from './updaters/cache-warming-updater';
 import { SetDef, LocationTypes } from './types';
@@ -12,17 +13,31 @@ var setDefs: SetDef[] = [];
 var fieldPacks = [
   { id: 'season', name: 'Season', defaultValue: '' },
   { id: 'occasionSlug', name: 'occasionSlug', defaultValue: '' },
-  { id: 'endYear', name: 'End year', defaultValue: (new Date().getFullYear() - 1).toString() },
+  {
+    id: 'endYear',
+    name: 'End year',
+    defaultValue: (new Date().getFullYear() - 1).toString(),
+  },
 ];
 
 (async function go() {
   window.addEventListener('error', reportTopLevelError);
   renderVersion();
-  renderMetadataForm({ fieldPacks, runMetadataGeneration, onMetadata });
+  renderMetadataForm({
+    fieldPacks,
+    runMetadataGeneration,
+    onMetadata: onMetadataGenerated,
+  });
   renderSets({ setDefs, onAddSet });
+  renderMetadata({ metadata: {}, onManualMetadataEdit });
   var warmingUpdater = CacheWarmingUpdater();
 
-  function onMetadata(metadata: unknown) {
+  function onMetadataGenerated(metadata: unknown) {
+    renderMetadata({ metadata, onManualMetadataEdit });
+    warmingUpdater.setMetadata(metadata);
+  }
+
+  function onManualMetadataEdit(metadata: unknown) {
     warmingUpdater.setMetadata(metadata);
   }
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "handle-error-web": "^1.0.1",
         "lodash.memoize": "^4.1.2",
         "lodash.omit": "^4.5.0",
+        "no-throw-json-parse": "^1.0.0",
         "object-form": "^0.10.1"
       },
       "devDependencies": {
@@ -1668,6 +1669,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/no-throw-json-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/no-throw-json-parse/-/no-throw-json-parse-1.0.0.tgz",
+      "integrity": "sha512-Jmlxa5pBaOp7kYk44hwg8QNS6cG435tUjmAuRuXCJHGi1w3rMidtHFcrUyhKVbip1emEwxKiHZ+awEwsWh7WhA=="
     },
     "node_modules/object-form": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "handle-error-web": "^1.0.1",
     "lodash.memoize": "^4.1.2",
     "lodash.omit": "^4.5.0",
+    "no-throw-json-parse": "^1.0.0",
     "object-form": "^0.10.1"
   }
 }

--- a/renderers/render-metadata.js
+++ b/renderers/render-metadata.js
@@ -1,13 +1,24 @@
-// import handleError from 'handle-error-web';
+import { select } from 'd3-selection';
+import noThrowJSONParse from 'no-throw-json-parse';
 
 var jsonFieldEl = document.getElementById('json-field');
 var downloadLinkEl = document.getElementById('download-link');
 
-export function renderMetadata({ metadata }) {
+export function renderMetadata({ metadata, onManualMetadataEdit }) {
+  if (onManualMetadataEdit) {
+    select(jsonFieldEl).on('blur', notifyAboutJSONChange);
+  }
   const metadataString = JSON.stringify(metadata, null, 2);
   jsonFieldEl.value = metadataString;
   const dataURL = `data:application/json,${encodeURIComponent(metadataString)}`;
   downloadLinkEl.download = 'metadata.json';
   downloadLinkEl.href = dataURL;
   downloadLinkEl.classList.remove('hidden');
+
+  function notifyAboutJSONChange() {
+    var metadata = noThrowJSONParse(jsonFieldEl.value);
+    if (metadata) {
+      onManualMetadataEdit(metadata);
+    }
+  }
 }

--- a/updaters/run-metadata-generation.ts
+++ b/updaters/run-metadata-generation.ts
@@ -1,6 +1,5 @@
 import { generateMetadata } from '../tasks/generate-metadata';
 import handleError from 'handle-error-web';
-import { renderMetadata } from '../renderers/render-metadata';
 import { ObjectFromDOM } from 'object-form';
 import { SetDef } from '../types';
 
@@ -28,7 +27,6 @@ export async function runMetadataGeneration({
 
     var metadata = await generateMetadata({ overallOpts, setDefs });
     onMetadata(metadata);
-    renderMetadata({ metadata });
   } catch (error) {
     handleError(error);
   }


### PR DESCRIPTION
Support visiting urls in manually entered JSON as well as in generated JSON. Changes include the generation updater reporting the generated metadata instead of rendering it directly and a handler in the metadata renderer that reports manual edits to the metadata.

The use case covered by this change is the user already having metadata that they want to use to warm the cache without having to regenerate the metadata.

FYI @dndodson 