### PR TITLE
Move 'season' and 'occasionSlug' to graphic set

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,8 +11,6 @@ import { SetDef, LocationTypes } from './types';
 var setDefs: SetDef[] = [];
 
 var fieldPacks = [
-  { id: 'season', name: 'Season', defaultValue: '' },
-  { id: 'occasionSlug', name: 'occasionSlug', defaultValue: '' },
   {
     id: 'endYear',
     name: 'End year',

--- a/renderers/render-sets.js
+++ b/renderers/render-sets.js
@@ -5,7 +5,9 @@ import { renderForm } from './render-form';
 var fieldPacks = [
   { id: 'name', name: 'Graphic set name', defaultValue: 'Default set name' },
   { id: 'graphicType', name: 'graphicType', defaultValue: 'lineChart' },
+  { id: 'occasionSlug', name: 'occasionSlug', defaultValue: '' },
   { id: 'variable', name: 'variable', defaultValue: 'mean_tavg' },
+  { id: 'season', name: 'season', defaultValue: '' },
   { id: 'locationType', name: 'locationType', defaultValue: 'market' },
   { id: 'ticksCount', name: 'Ticks count', defaultValue: '3' },
   // TODO: Bring these back after graphics supports them in the URL.

--- a/tasks/generate-metadata.ts
+++ b/tasks/generate-metadata.ts
@@ -36,7 +36,7 @@ export async function generateMetadata({
     ['title', 'notitle'],
     // backgroundCombo
     [
-      { name: 'imageBG', backgroundType: 'Image URL' },
+      { name: 'imageBG', backgroundType: undefined },
       { name: 'noBG', backgroundType: 'Solid', backgroundStartColor: 'none' },
     ],
     // lang
@@ -60,20 +60,23 @@ export async function generateMetadata({
     let graphicURLOpts: GraphicURLOpts = Object.assign({
       graphicType: setDef.graphicType,
       variable: setDef.variable,
-      season: overallOpts.season,
+      season: setDef.season,
       endYear: overallOpts.endYear,
       ticksCount: setDef.ticksCount,
       lang,
       noTitle: titleEnum === 'notitle',
       marketSlug,
-      backgroundType: backgroundCombo.backgroundType,
-      backgroundStartColor: backgroundCombo.backgroundStartColor,
     });
+
+    if (backgroundCombo.backgroundType !== undefined && backgroundCombo.backgroundStartColor !== undefined) {
+      graphicURLOpts.backgroundType = backgroundCombo.backgroundType;
+      graphicURLOpts.backgroundStartColor = backgroundCombo.backgroundStartColor;
+    }
 
     // The graphics lib determines season from occasionSlug based on its config;
     // therefore we pass either season (default) or only occasionSlug as a URL param.
-    if (overallOpts.occasionSlug) {
-      graphicURLOpts.occasionSlug = overallOpts.occasionSlug;
+    if (setDef.occasionSlug) {
+      graphicURLOpts.occasionSlug = setDef.occasionSlug;
       delete graphicURLOpts.season;
     }
 
@@ -100,10 +103,10 @@ export async function generateMetadata({
     return {
       graphicSet: setDef.name,
       url: `${IMG_URL_BASE}/?delay=3000&cache=${cache}&url=${encodeURIComponent(graphicURL)}`,
-      graphicURL,
+      htmlURL: graphicURL,
       title: titleEnum,
       lang,
-      extension: backgroundCombo.backgroundType === 'Image URL' ? 'jpg' : 'png',
+      extension: backgroundCombo.backgroundType === 'None' ? 'png' : 'jpg',
       location: {
         key: marketSlug,
         name: marketData[marketSlug].name,
@@ -111,10 +114,10 @@ export async function generateMetadata({
         longitude: null,
       },
       downloadable: setDef.downloadable,
-      season: overallOpts.season,
+      season: setDef.season,
       variable: setDef.variable,
       setType: setDef.name,
-      dataURL: setDef.downloadable ? `${DATA_URL_BASE}/api/v1/graphic-data/trend/?agg_time=${overallOpts.season}&station_id=${marketData[marketSlug].station}&trend_year_range=1970-${overallOpts.endYear}&variable=${setDef.variable}&format=csv` : null,
+      dataURL: setDef.downloadable ? `${DATA_URL_BASE}/api/v1/graphic-data/trend/?agg_time=${setDef.season}&station_id=${marketData[marketSlug].station}&trend_year_range=1970-${overallOpts.endYear}&variable=${setDef.variable}&format=csv` : null,
     };
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -3,7 +3,7 @@ export enum LocationTypes {
   conus = 'conus',
 }
 
-export type BackgroundType = 'Linear Gradient' | 'Image URL' | 'Solid' | 'None';
+export type BackgroundType = undefined | 'Linear Gradient' | 'Image URL' | 'Solid' | 'None';
 export type BackgroundCombo = {
   name: string;
   backgroundType: BackgroundType;
@@ -14,6 +14,8 @@ export interface SetDef {
   name: string;
   graphicType: 'lineChart' | 'mapGraphic';
   variable: string;
+  season?: string;
+  occasionSlug?: string;
   backgroundType?: BackgroundType;
   imageURL?: string;
   backgroundStartColor?: string;
@@ -30,16 +32,12 @@ export enum TitleEnum {
 
 export interface GraphicURLOpts extends Omit<SetDef, 'locations'> {
   // [key: string]: string | boolean | undefined
-  occasionSlug: string;
   lang: string;
   noTitle: boolean;
   marketSlug?: string;
-  season?: string;
 }
 
 export interface OverallOpts {
-  occasionSlug: string;
-  season: string;
   endYear: number;
 }
 


### PR DESCRIPTION
These may vary within a package. For example, we may want to publish a package with graphics for every season. Or all holidays.